### PR TITLE
Update the IP address with the one used in the demo client

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In order to test pCAS library, you must run the server:
 ```
 cd demo-server
 composer install
-php bin/console server:run 127.0.1.1:8001
+php bin/console server:run 127.0.0.1:8001
 ```
 
 Then run the web app:


### PR DESCRIPTION
The Readme suggests to use `127.0.1.1:8001` as the server location, but when I try to connect through the client I get:

> can’t establish a connection to the server at 127.0.0.1:8001