### PR TITLE
OPENEUROPA-754: Parameters in pCAS service file to be easy to be overridden

### DIFF
--- a/Resources/config/p_cas.yml
+++ b/Resources/config/p_cas.yml
@@ -25,7 +25,7 @@ parameters:
 services:
   pcas:
     class: OpenEuropa\pcas\PCas
-    arguments: ['@?pcas.config', '@?pcas.httpclient', '@?pcas.protocol', '@?session']
+    arguments: ['@?pcas.config','@?pcas.httpclient','@?pcas.protocol','@?session']
     public: true
 
   pcas.httpclient:
@@ -34,17 +34,7 @@ services:
 
   pcas.config:
     class: OpenEuropa\pcas\Config\PcasConfig
-    arguments: ['%protocol.login.uri%'
-                '%protocol.login.query%'
-                '%protocol.login.allowed_parameters%'
-                '%protocol.logout.uri%'
-                '%protocol.logout.query%'
-                '%protocol.logout.allowed_parameters%'
-                '%protocol.servicevalidate.uri%'
-                '%protocol.servicevalidate.query%'
-                '%protocol.servicevalidate.allowed_parameters%'n
-                '%logger_startup_message%'
-                ]
+    arguments: ['%protocol.login.uri%','%protocol.login.query%','%protocol.login.allowed_parameters%','%protocol.logout.uri%','%protocol.logout.query%','%protocol.logout.allowed_parameters%','%protocol.servicevalidate.uri%','%protocol.servicevalidate.query%','%protocol.servicevalidate.allowed_parameters%','%logger_startup_message%']
     public: true
 
   pcas.protocol:

--- a/Resources/config/p_cas.yml
+++ b/Resources/config/p_cas.yml
@@ -1,38 +1,56 @@
 parameters:
-  p_cas:
-    logger_startup_message: 'Logger just got started!!! (from original config)'
-    protocol:
-      login:
-        uri: http://127.0.0.1:8000/login
-        query: []
-        allowed_parameters:
-          - service
-          - renew
-          - gateway
-      servicevalidate:
-        uri: http://127.0.0.1:8000/serviceValidate
-        query: []
-        allowed_parameters:
-          - service
-          - ticket
-          - pgtUrl
-          - renew
-          - format
-      logout:
-        uri: http://127.0.0.1:8000/logout
-        query: []
-        allowed_parameters:
-          - service
+  logger_startup_message: 'Logger just got started!!! (from original config)'
+
+  protocol.login.uri: http://127.0.0.1:8000/login
+  protocol.login.query: []
+  protocol.login.allowed_parameters:
+    - service
+    - renew
+    - gateway
+
+  protocol.servicevalidate.uri: http://127.0.0.1:8000/serviceValidate
+  protocol.servicevalidate.query: []
+  protocol.servicevalidate.allowed_parameters:
+    - service
+    - ticket
+    - pgtUrl
+    - renew
+    - format
+
+  protocol.logout.uri: http://127.0.0.1:8000/logout
+  protocol.logout.query: []
+  protocol.logout.allowed_parameters:
+    - service
 
 services:
   pcas:
     class: OpenEuropa\pcas\PCas
-    arguments: ['%p_cas%', '@?pcas.httpclient', '@?pcas.protocol', '@?session']
+    arguments: [
+      '@?pcas.config',
+      '@?pcas.httpclient',
+      '@?pcas.protocol',
+      '@?session',
+    ]
     public: true
 
   pcas.httpclient:
     class: OpenEuropa\pcas\Http\Client
     factory: 'pcas.httpclientfactory:getHttpClient'
+
+  pcas.config:
+    class: OpenEuropa\pcas\Config\PcasConfig
+    arguments: ['%protocol.login.uri%'
+                '%protocol.login.query%'
+                '%protocol.login.allowed_parameters%'ers%'
+                '%protocol.logout.uri%'
+                '%protocol.logout.query%'
+                '%protocol.logout.allowed_parameters%'
+                '%protocol.servicevalidate.uri%'
+                '%protocol.servicevalidate.query%'
+                '%protocol.servicevalidate.allowed_paramet
+                '%logger_startup_message%'
+                ]
+    public: true
 
   pcas.protocol:
     class: OpenEuropa\pcas\Cas\Protocol\V2\CasProtocolV2

--- a/Resources/config/p_cas.yml
+++ b/Resources/config/p_cas.yml
@@ -41,13 +41,13 @@ services:
     class: OpenEuropa\pcas\Config\PcasConfig
     arguments: ['%protocol.login.uri%'
                 '%protocol.login.query%'
-                '%protocol.login.allowed_parameters%'ers%'
+                '%protocol.login.allowed_parameters%'
                 '%protocol.logout.uri%'
                 '%protocol.logout.query%'
                 '%protocol.logout.allowed_parameters%'
                 '%protocol.servicevalidate.uri%'
                 '%protocol.servicevalidate.query%'
-                '%protocol.servicevalidate.allowed_paramet
+                '%protocol.servicevalidate.allowed_parameters%'n
                 '%logger_startup_message%'
                 ]
     public: true

--- a/Resources/config/p_cas.yml
+++ b/Resources/config/p_cas.yml
@@ -25,12 +25,7 @@ parameters:
 services:
   pcas:
     class: OpenEuropa\pcas\PCas
-    arguments: [
-      '@?pcas.config',
-      '@?pcas.httpclient',
-      '@?pcas.protocol',
-      '@?session',
-    ]
+    arguments: ['@?pcas.config', '@?pcas.httpclient', '@?pcas.protocol', '@?session']
     public: true
 
   pcas.httpclient:

--- a/demo-client/composer.json
+++ b/demo-client/composer.json
@@ -3,7 +3,7 @@
     "license": "proprietary",
     "require": {
         "php": "^7.1",
-        "OpenEuropa/pcas": "dev-master",
+        "OpenEuropa/pcas": "dev-OPENEUROPA-754",
         "php-http/guzzle6-adapter": "^1.1",
         "php-http/httplug-bundle": "^1.1",
         "sensio/framework-extra-bundle": "^5.0",

--- a/demo-client/symfony.lock
+++ b/demo-client/symfony.lock
@@ -17,11 +17,20 @@
     "doctrine/common": {
         "version": "v2.8.1"
     },
+    "doctrine/event-manager": {
+        "version": "v1.0.0"
+    },
     "doctrine/inflector": {
         "version": "v1.2.0"
     },
     "doctrine/lexer": {
         "version": "v1.0.1"
+    },
+    "doctrine/persistence": {
+        "version": "v1.0.0"
+    },
+    "doctrine/reflection": {
+        "version": "v1.0.0"
     },
     "guzzlehttp/guzzle": {
         "version": "6.3.0"
@@ -184,6 +193,9 @@
     },
     "symfony/options-resolver": {
         "version": "v3.3.11"
+    },
+    "symfony/polyfill-ctype": {
+        "version": "v1.8.0"
     },
     "symfony/polyfill-mbstring": {
         "version": "v1.6.0"

--- a/demo-server/composer.json
+++ b/demo-server/composer.json
@@ -3,7 +3,7 @@
     "license": "proprietary",
     "require": {
         "php": "^7.0.8",
-        "OpenEuropa/pcas": "dev-master",
+        "OpenEuropa/pcas": "dev-OPENEUROPA-754",
         "guzzlehttp/psr7": "^1.4",
         "php-http/guzzle6-adapter": "^1.1",
         "sensio/framework-extra-bundle": "^5.0",

--- a/demo-server/symfony.lock
+++ b/demo-server/symfony.lock
@@ -17,11 +17,20 @@
     "doctrine/common": {
         "version": "v2.8.1"
     },
+    "doctrine/event-manager": {
+        "version": "v1.0.0"
+    },
     "doctrine/inflector": {
         "version": "v1.2.0"
     },
     "doctrine/lexer": {
         "version": "v1.0.1"
+    },
+    "doctrine/persistence": {
+        "version": "v1.0.0"
+    },
+    "doctrine/reflection": {
+        "version": "v1.0.0"
     },
     "guzzlehttp/guzzle": {
         "version": "6.3.0"
@@ -166,6 +175,9 @@
     },
     "symfony/polyfill-apcu": {
         "version": "v1.6.0"
+    },
+    "symfony/polyfill-ctype": {
+        "version": "v1.8.0"
     },
     "symfony/polyfill-intl-icu": {
         "version": "v1.6.0"

--- a/spec/OpenEuropa/pcas/PCasSpec.php
+++ b/spec/OpenEuropa/pcas/PCasSpec.php
@@ -4,6 +4,7 @@ namespace spec\OpenEuropa\pcas;
 use OpenEuropa\pcas\Cas\Protocol\V2\CasProtocolV2;
 use OpenEuropa\pcas\Http\HttpClientFactory;
 use OpenEuropa\pcas\PCas;
+use OpenEuropa\pcas\Config\PcasConfig;
 use OpenEuropa\pcas\Security\Core\User\PCasUserFactory;
 use OpenEuropa\pcas\Utils\PCasSerializerFactory;
 use PhpSpec\ObjectBehavior;
@@ -32,6 +33,21 @@ class PCasSpec extends ObjectBehavior
         ];
     }
 
+    public function getPcasConfig() : PcasConfig
+    {
+        return new PcasConfig(
+            'http://cas-server/login',
+            [],
+            ['service'],
+            'http://cas-server/logout',
+            [],
+            ['service'],
+            '',
+            [],
+            [],
+            ''
+            );
+    }
     public function setUpClient()
     {
         $_SERVER['HTTP_HOST'] = 'cas-client';
@@ -51,7 +67,8 @@ class PCasSpec extends ObjectBehavior
         $session = new Session();
 
         $this->beConstructedWith(
-            $this->getProperties(),
+//            $this->getProperties(),
+            $this->getPcasConfig(),
             $client,
             $protocol,
             $session

--- a/spec/OpenEuropa/pcas/PCasSpec.php
+++ b/spec/OpenEuropa/pcas/PCasSpec.php
@@ -2,9 +2,9 @@
 namespace spec\OpenEuropa\pcas;
 
 use OpenEuropa\pcas\Cas\Protocol\V2\CasProtocolV2;
+use OpenEuropa\pcas\Config\PcasConfig;
 use OpenEuropa\pcas\Http\HttpClientFactory;
 use OpenEuropa\pcas\PCas;
-use OpenEuropa\pcas\Config\PcasConfig;
 use OpenEuropa\pcas\Security\Core\User\PCasUserFactory;
 use OpenEuropa\pcas\Utils\PCasSerializerFactory;
 use PhpSpec\ObjectBehavior;

--- a/src/Cas/Protocol/V2/CasProtocolV2.php
+++ b/src/Cas/Protocol/V2/CasProtocolV2.php
@@ -48,39 +48,6 @@ class CasProtocolV2 extends AbstractCasProtocol
             }
             $pCasUser = $validatedResponse;
 
-
-            //check if a ProxyGrantingTicketIOU was set
-            if ($requestPgt
-                && StringUtils::isNotEmpty($proxyGrantingTicketCallback)
-                && StringUtils::isNotEmpty($pCasUser->getPgtIOU())
-            ) {
-                $pgtiou = $pCasUser->getPgtIOU();
-
-                //checking if we have a PGTIOU in the cache
-                /*
-                                if ($this->getCache()->has($pgtiou)) {
-                                    $pCasUser->setProxyGrantingTicket(
-                                      $this->getCache()->get(
-                                        $pgtiou
-                                      )->getValue()
-                                    );
-
-                                    $this->getLogger()->debug(sprintf(
-                                      '
-                              Found PGT %s for PGTIOU %s',
-                                      $pCasUser->getProxyGrantingTicket(),
-                                      $pgtiou
-                                    ));
-                                } else {
-                                    $this->getLogger()->warn(sprintf(
-                                      '
-                              Could not find any PGT in the cache for IOU: %s',
-                                      $pgtiou
-                                    ));
-                                }
-                */
-            }
-
             $this->getSession()->set('pcas/user', $pCasUser);
 
             return true;
@@ -109,7 +76,7 @@ class CasProtocolV2 extends AbstractCasProtocol
             return false;
         }
 
-        //check if the validation was ok!
+        // Check if the validation was ok!
         if (!isset($root['cas:authenticationSuccess'])) {
             // @todo: log
             return false;

--- a/src/Config/PcasConfig.php
+++ b/src/Config/PcasConfig.php
@@ -286,7 +286,7 @@ class PcasConfig
                     ],
 
                     'logout' => [
-                        'uri' => $this->getLoginUri(),
+                        'uri' => $this->getLogoutUri(),
                         'query' => $this->getLogoutQuery(),
                         'allowed_parameters' => $this->getLogoutAllowedParams(),
                     ],

--- a/src/Config/PcasConfig.php
+++ b/src/Config/PcasConfig.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: aritoadmin
- * Date: 02/08/2018
- * Time: 14:39
- */
 
 namespace OpenEuropa\pcas\Config;
-
 
 class PcasConfig
 {
@@ -15,61 +8,61 @@ class PcasConfig
      * @var string
      *  A logger message.
      */
-   private $loggerStartupMessage;
+    private $loggerStartupMessage;
 
     /**
-     * @var string
-     *  The login uri.
-     */
-   private $loginUri;
+    * @var string
+    *  The login uri.
+    */
+    private $loginUri;
 
     /**
-     * @var array
-     *  A logger message.
-     */
-   private $loginQuery;
+    * @var array
+    *  A logger message.
+    */
+    private $loginQuery;
 
     /**
      * @var array
      *  An array with all allowed login parameters.
      */
-   private $loginAllowedParams;
+    private $loginAllowedParams;
 
     /**
      * @var string
      *  The logout uri.
      */
-   private $logoutUri;
+    private $logoutUri;
 
     /**
      * @var array
      *  A logout query to be validated.
      */
-   private $logoutQuery;
+    private $logoutQuery;
 
     /**
      * @var array
      *  An array with all allowed logout parameters.
      */
-   private $logoutAllowedParams;
+    private $logoutAllowedParams;
 
     /**
      * @var string
      *  The service validate uri.
      */
-   private $serviceValidateUri;
+    private $serviceValidateUri;
 
     /**
      * @var array
      *  A query to be validated.
      */
-   private $serviceValidateQuery;
+    private $serviceValidateQuery;
 
     /**
      * @var array
      *  An array with all allowed query parameters.
      */
-   private $serviceValidateAllowedParams;
+    private $serviceValidateAllowedParams;
 
     /**
      * PcasConfig constructor.
@@ -85,30 +78,29 @@ class PcasConfig
      * @param array $serviceValidateAllowedParams
      * @param string $loggerStartupMessage
      */
-   public function __construct(
-       string $loginUri,
-       array $loginQuery,
-       array $loginAllowedParams,
-       string $logoutUri,
-       array $logoutQuery,
-       array $logoutAllowedParams,
-       string $serviceValidateUri,
-       array $serviceValidateQuery,
-       array $serviceValidateAllowedParams,
-       string $loggerStartupMessage = ''
-     )
-   {
-       $this->setLoginUri($loginUri);
-       $this->setLoginQuery($loginQuery);
-       $this->setLoginAllowedParams($loginAllowedParams);
-       $this->setServiceValidateUri($serviceValidateUri);
-       $this->setserviceValidateQuery($serviceValidateQuery);
-       $this->setServiceValidateAllowedParams($serviceValidateAllowedParams);
-       $this->setLogoutUri($logoutUri);
-       $this->setLogoutQuery($logoutQuery);
-       $this->setLogoutAllowedParams($logoutAllowedParams);
-       $this->setLoggerStartupMessage($loggerStartupMessage);
-   }
+    public function __construct(
+        string $loginUri,
+        array $loginQuery,
+        array $loginAllowedParams,
+        string $logoutUri,
+        array $logoutQuery,
+        array $logoutAllowedParams,
+        string $serviceValidateUri,
+        array $serviceValidateQuery,
+        array $serviceValidateAllowedParams,
+        string $loggerStartupMessage = ''
+    ) {
+        $this->setLoginUri($loginUri);
+        $this->setLoginQuery($loginQuery);
+        $this->setLoginAllowedParams($loginAllowedParams);
+        $this->setServiceValidateUri($serviceValidateUri);
+        $this->setserviceValidateQuery($serviceValidateQuery);
+        $this->setServiceValidateAllowedParams($serviceValidateAllowedParams);
+        $this->setLogoutUri($logoutUri);
+        $this->setLogoutQuery($logoutQuery);
+        $this->setLogoutAllowedParams($logoutAllowedParams);
+        $this->setLoggerStartupMessage($loggerStartupMessage);
+    }
 
     /**
      * @return string
@@ -227,7 +219,7 @@ class PcasConfig
     /**
      * @return string
      */
-    public function getserviceValidateUri(): string
+    public function getServiceValidateUri(): string
     {
         return $this->serviceValidateUri;
     }
@@ -301,5 +293,4 @@ class PcasConfig
                 'logger_startup_message' => $this->getLoggerStartupMessage(),
         ];
     }
-
 }

--- a/src/Config/PcasConfig.php
+++ b/src/Config/PcasConfig.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: aritoadmin
+ * Date: 02/08/2018
+ * Time: 14:39
+ */
+
+namespace OpenEuropa\pcas\Config;
+
+
+class PcasConfig
+{
+    /**
+     * @var string
+     *  A logger message.
+     */
+   private $loggerStartupMessage;
+
+    /**
+     * @var string
+     *  The login uri.
+     */
+   private $loginUri;
+
+    /**
+     * @var array
+     *  A logger message.
+     */
+   private $loginQuery;
+
+    /**
+     * @var array
+     *  An array with all allowed login parameters.
+     */
+   private $loginAllowedParams;
+
+    /**
+     * @var string
+     *  The logout uri.
+     */
+   private $logoutUri;
+
+    /**
+     * @var array
+     *  A logout query to be validated.
+     */
+   private $logoutQuery;
+
+    /**
+     * @var array
+     *  An array with all allowed logout parameters.
+     */
+   private $logoutAllowedParams;
+
+    /**
+     * @var string
+     *  The service validate uri.
+     */
+   private $serviceValidateUri;
+
+    /**
+     * @var array
+     *  A query to be validated.
+     */
+   private $serviceValidateQuery;
+
+    /**
+     * @var array
+     *  An array with all allowed query parameters.
+     */
+   private $serviceValidateAllowedParams;
+
+    /**
+     * PcasConfig constructor.
+     *
+     * @param string $loginUri
+     * @param array $loginQuery
+     * @param array $loginAllowedParams
+     * @param string $logoutUri
+     * @param array $logoutQuery
+     * @param array $logoutAllowedParams
+     * @param string $serviceValidateUri
+     * @param array $serviceValidateQuery
+     * @param array $serviceValidateAllowedParams
+     * @param string $loggerStartupMessage
+     */
+   public function __construct(
+       string $loginUri,
+       array $loginQuery,
+       array $loginAllowedParams,
+       string $logoutUri,
+       array $logoutQuery,
+       array $logoutAllowedParams,
+       string $serviceValidateUri,
+       array $serviceValidateQuery,
+       array $serviceValidateAllowedParams,
+       string $loggerStartupMessage = ''
+     )
+   {
+       $this->setLoginUri($loginUri);
+       $this->setLoginQuery($loginQuery);
+       $this->setLoginAllowedParams($loginAllowedParams);
+       $this->setServiceValidateUri($serviceValidateUri);
+       $this->setserviceValidateQuery($serviceValidateQuery);
+       $this->setServiceValidateAllowedParams($serviceValidateAllowedParams);
+       $this->setLogoutUri($logoutUri);
+       $this->setLogoutQuery($logoutQuery);
+       $this->setLogoutAllowedParams($logoutAllowedParams);
+       $this->setLoggerStartupMessage($loggerStartupMessage);
+   }
+
+    /**
+     * @return string
+     */
+    public function getLoggerStartupMessage(): string
+    {
+        return $this->loggerStartupMessage;
+    }
+
+    /**
+     * @param string $loggerStartupMessage
+     */
+    public function setLoggerStartupMessage(string $loggerStartupMessage)
+    {
+        $this->loggerStartupMessage = $loggerStartupMessage;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLoginUri(): string
+    {
+        return $this->loginUri;
+    }
+
+    /**
+     * @param string $loginUri
+     */
+    public function setLoginUri(string $loginUri)
+    {
+        $this->loginUri = $loginUri;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLoginQuery(): array
+    {
+        return $this->loginQuery;
+    }
+
+    /**
+     * @param array $loginQuery
+     */
+    public function setLoginQuery(array $loginQuery)
+    {
+        $this->loginQuery = $loginQuery;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLoginAllowedParams(): array
+    {
+        return $this->loginAllowedParams;
+    }
+
+    /**
+     * Set the allowed parameters.
+     *
+     * @param array $loginAllowedParams
+     */
+    public function setLoginAllowedParams(array $loginAllowedParams)
+    {
+        $this->loginAllowedParams = $loginAllowedParams;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLogoutUri(): string
+    {
+        return $this->logoutUri;
+    }
+
+    /**
+     * @param string $logoutUri
+     */
+    public function setLogoutUri(string $logoutUri)
+    {
+        $this->logoutUri = $logoutUri;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLogoutQuery(): array
+    {
+        return $this->logoutQuery;
+    }
+
+    /**
+     * @param array $logoutQuery
+     */
+    public function setLogoutQuery(array $logoutQuery)
+    {
+        $this->logoutQuery = $logoutQuery;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLogoutAllowedParams(): array
+    {
+        return $this->logoutAllowedParams;
+    }
+
+    /**
+     * @param array $logoutAllowedParams
+     */
+    public function setLogoutAllowedParams(array $logoutAllowedParams)
+    {
+        $this->logoutAllowedParams = $logoutAllowedParams;
+    }
+
+    /**
+     * @return string
+     */
+    public function getserviceValidateUri(): string
+    {
+        return $this->serviceValidateUri;
+    }
+
+    /**
+     * @param string $serviceValidateUri
+     */
+    public function setServiceValidateUri(string $serviceValidateUri)
+    {
+        $this->serviceValidateUri = $serviceValidateUri;
+    }
+
+    /**
+     * @return array
+     */
+    public function getServiceValidateQuery(): array
+    {
+        return $this->serviceValidateQuery;
+    }
+
+    /**
+     * @param array $serviceValidateQuery
+     */
+    public function setServiceValidateQuery(array $serviceValidateQuery)
+    {
+        $this->serviceValidateQuery = $serviceValidateQuery;
+    }
+
+    /**
+     * @return array
+     */
+    public function getServiceValidateAllowedParams(): array
+    {
+        return $this->serviceValidateAllowedParams;
+    }
+
+    /**
+     * @param array $serviceValidateAllowedParams
+     */
+    public function setServiceValidateAllowedParams(array $serviceValidateAllowedParams)
+    {
+        $this->serviceValidateAllowedParams = $serviceValidateAllowedParams;
+    }
+
+    /**
+     * @return array
+     */
+    public function getProperties(): array
+    {
+        return [
+                'protocol' => [
+                    'login' => [
+                        'uri' => $this->getLoginUri(),
+                        'query' => $this->getLoginQuery(),
+                        'allowed_parameters' => $this->getLoginAllowedParams(),
+                    ],
+
+                    'logout' => [
+                        'uri' => $this->getLoginUri(),
+                        'query' => $this->getLogoutQuery(),
+                        'allowed_parameters' => $this->getLogoutAllowedParams(),
+                    ],
+
+                    'servicevalidate' => [
+                        'uri' => $this->serviceValidateUri,
+                        'query' => $this->getServiceValidateQuery(),
+                        'allowed_parameters' => $this->getServiceValidateAllowedParams(),
+                    ],
+                ],
+
+                'logger_startup_message' => $this->getLoggerStartupMessage(),
+        ];
+    }
+
+}

--- a/src/PCas.php
+++ b/src/PCas.php
@@ -2,6 +2,7 @@
 namespace OpenEuropa\pcas;
 
 use OpenEuropa\pcas\Cas\Protocol\CasProtocolInterface;
+use OpenEuropa\pcas\Config\PcasConfig;
 use OpenEuropa\pcas\Http\HttpClientInterface;
 use OpenEuropa\pcas\Security\Core\User\PCasUser;
 use OpenEuropa\pcas\Utils\GlobalVariablesGetter;
@@ -19,6 +20,7 @@ class PCas implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
+    /* The api version should be removed from here*/
     const VERSION = '0.0.1';
 
     /**
@@ -68,8 +70,7 @@ class PCas implements LoggerAwareInterface
     /**
      * PCas constructor.
      *
-     * @param array $properties
-     *   The properties.
+     * @param \OpenEuropa\pcas\Config\PcasConfig $pcasConfig
      * @param \OpenEuropa\pcas\Http\HttpClientInterface $client
      * @param \OpenEuropa\pcas\Cas\Protocol\CasProtocolInterface $protocol
      * @param \Symfony\Component\HttpFoundation\Session\SessionInterface $session
@@ -77,14 +78,14 @@ class PCas implements LoggerAwareInterface
      * @param \Psr\Log\LoggerInterface|null $logger
      */
     public function __construct(
-        array $properties,
+        PcasConfig $pcasConfig,
         HttpClientInterface $client,
         CasProtocolInterface $protocol,
         SessionInterface $session,
         CacheInterface $cache = null,
         LoggerInterface $logger = null
     ) {
-        $this->setProperties($properties);
+        $this->setProperties($pcasConfig);
 
         $this->setHttpClient($client);
         $this->setProtocol(
@@ -185,14 +186,14 @@ class PCas implements LoggerAwareInterface
     /**
      * Set the properties.
      *
-     * @param array $properties
-     *   The properties.
+     * @param \OpenEuropa\pcas\Config\PcasConfig $pcasConfig
+     *   The pcas configuration service.
      *
      * @return \OpenEuropa\pcas\PCas
      */
-    public function setProperties(array $properties)
+    public function setProperties($pcasConfig)
     {
-        $this->properties = $properties;
+        $this->properties = $pcasConfig->getProperties();
 
         return $this;
     }


### PR DESCRIPTION
- Create:
  New service that encapsulates all pcas settings (allowing to pass the service to the pCAS constructor instead of a set of config)
All config entry has been flattening so it can be easier to override them (can be selectively overridden)